### PR TITLE
Semantic conventions for browser navigation/resource events

### DIFF
--- a/specification/logs/semantic_conventions/events/README.md
+++ b/specification/logs/semantic_conventions/events/README.md
@@ -2,6 +2,6 @@
 
 Events in OpenTelemetry are a subset of logs with specific set of semantic conventions.
 
-Each events MUST follow the [`events.*`](./events.md) semantic conventions, and it must follow semantic conventions specific for the type of event 
+Each event MUST follow the [`events.*`](./events.md) semantic conventions, and it must follow semantic conventions specific for the type of event.
 
-Each event has a name (`event.name`) attribute, which uniquely identifies the type of the event. In addition 
+Each event is uniquely identified by the combination of name  (`event.name` attribute) and domain (`event.domain` attribute). Each subfolder in this folder represents a domain. Individual files in the subfolders represent semantic conventions specific to individual events.

--- a/specification/logs/semantic_conventions/events/README.md
+++ b/specification/logs/semantic_conventions/events/README.md
@@ -1,0 +1,7 @@
+# Events semantic conventions
+
+Events in OpenTelemetry are a subset of logs with specific set of semantic conventions.
+
+Each events MUST follow the [`events.*`](./events.md) semantic conventions, and it must follow semantic conventions specific for the type of event 
+
+Each event has a name (`event.name`) attribute, which uniquely identifies the type of the event. In addition 

--- a/specification/logs/semantic_conventions/events/browser/README.md
+++ b/specification/logs/semantic_conventions/events/browser/README.md
@@ -1,0 +1,9 @@
+# Browser events semantic conventions
+
+All browser events MUST have the `event.domain` attribute set to `browser`.
+
+| Event name | Description |
+|---|---|
+| [`navigation`](./navigation.md) | Represents a page navigation event with values from the Navigation Timing API |
+| [`resource`](./resource.md) | Represents a resource with values from the Resource Timing API |
+ 

--- a/specification/logs/semantic_conventions/events/browser/navigation.md
+++ b/specification/logs/semantic_conventions/events/browser/navigation.md
@@ -8,7 +8,7 @@
 
 <!-- semconv browser -->
 | Attribute  | Type | Value  | Requirement Level |
-|---|---|---|---|---|
+|---|---|---|---|
 | `event.name` | string | `navigation` | Required |
 | `event.domain | string | `browser` | Required |
 <!-- endsemconv -->
@@ -19,7 +19,7 @@ This list is not exhaustive and is listed as an example. All numeric and string 
 
 
 | Attribute  | Type | Example  | Requirement Level |
-|---|---|---|---|---|
+|---|---|---|---|
 | `unloadEventStart` | numeric | 0 | Optional |
 | `unloadEventEnd` | numeric | 0 | Optional |
 | `domInteractive` | numeric | 0 | Optional |

--- a/specification/logs/semantic_conventions/events/browser/navigation.md
+++ b/specification/logs/semantic_conventions/events/browser/navigation.md
@@ -1,0 +1,32 @@
+# Navigation
+
+**Status**: [Experimental](../../../../document-status.md)
+
+**type:** `navigation`
+
+**Description**: Represents a browser navigation event.
+
+<!-- semconv browser -->
+| Attribute  | Type | Value  | Requirement Level |
+|---|---|---|---|---|
+| `event.name` | string | `navigation` | Required |
+| `event.domain | string | `browser` | Required |
+<!-- endsemconv -->
+
+Additional attributes are mapped from the (Navigation Timing API)[https://www.w3.org/TR/navigation-timing-2/#sec-PerformanceNavigationTiming].
+
+This list is not exhaustive and is listed as an example. All numeric and string values thar are provided by the Navigation Timing API SHOULD be included.
+
+
+| Attribute  | Type | Example  | Requirement Level |
+|---|---|---|---|---|
+| `unloadEventStart` | numeric | 0 | Optional |
+| `unloadEventEnd` | numeric | 0 | Optional |
+| `domInteractive` | numeric | 0 | Optional |
+| `domContentLoadedEventStart` | numeric | 0 | Optional |
+| `domContentLoadedEventStart` | numeric | 0 | Optional |
+| `domComplete` | numeric | 0 | Optional |
+| `loadEventStart` | numeric | 0 | Optional |
+| `loadEventEnd` | numeric | 0 | Optional |
+| `type` | string | `navigate`; `reload`; `back_forward` | Optional |
+| `redirectCount` | numeric | 0 | Optional |

--- a/specification/logs/semantic_conventions/events/browser/navigation.md
+++ b/specification/logs/semantic_conventions/events/browser/navigation.md
@@ -6,6 +6,8 @@
 
 **Description**: Represents a browser navigation event.
 
+The following attributes MUST be set with these predefined values:
+
 <!-- semconv browser -->
 | Attribute  | Type | Value  | Requirement Level |
 |---|---|---|---|

--- a/specification/logs/semantic_conventions/events/browser/navigation.md
+++ b/specification/logs/semantic_conventions/events/browser/navigation.md
@@ -10,23 +10,24 @@
 | Attribute  | Type | Value  | Requirement Level |
 |---|---|---|---|
 | `event.name` | string | `navigation` | Required |
-| `event.domain | string | `browser` | Required |
+| `event.domain` | string | `browser` | Required |
 <!-- endsemconv -->
 
-Additional attributes are mapped from the (Navigation Timing API)[https://www.w3.org/TR/navigation-timing-2/#sec-PerformanceNavigationTiming].
+Additional attributes are mapped from the [Navigation Timing API](https://www.w3.org/TR/navigation-timing-2/#sec-PerformanceNavigationTiming).
 
 This list is not exhaustive and is listed as an example. All numeric and string values thar are provided by the Navigation Timing API SHOULD be included.
 
 
 | Attribute  | Type | Example  | Requirement Level |
 |---|---|---|---|
-| `unloadEventStart` | numeric | 0 | Optional |
-| `unloadEventEnd` | numeric | 0 | Optional |
-| `domInteractive` | numeric | 0 | Optional |
-| `domContentLoadedEventStart` | numeric | 0 | Optional |
-| `domContentLoadedEventStart` | numeric | 0 | Optional |
-| `domComplete` | numeric | 0 | Optional |
-| `loadEventStart` | numeric | 0 | Optional |
-| `loadEventEnd` | numeric | 0 | Optional |
-| `type` | string | `navigate`; `reload`; `back_forward` | Optional |
-| `redirectCount` | numeric | 0 | Optional |
+| `name` | string | `https://example.com/a/b` | Recommended |
+| `unloadEventStart` | double | 0 | Recommended |
+| `unloadEventEnd` | double | 0 | Recommended |
+| `domInteractive` | double | 1002.34 | Recommended |
+| `domContentLoadedEventStart` | double | 1423.54 | Recommended |
+| `domContentLoadedEventEnd` | double | 1428.51 | Recommended |
+| `domComplete` | double | 1512.43 | Recommended |
+| `loadEventStart` | double | 1589.23 | Recommended |
+| `loadEventEnd` | double | 1599.21 | Recommended |
+| `type` | string | `navigate`; `reload`; `back_forward` | Recommended |
+| `redirectCount` | int | 0 | Recommended |

--- a/specification/logs/semantic_conventions/events/browser/resource.md
+++ b/specification/logs/semantic_conventions/events/browser/resource.md
@@ -8,7 +8,7 @@
 
 <!-- semconv browser -->
 | Attribute  | Type | Value  | Requirement Level |
-|---|---|---|---|---|
+|---|---|---|---|
 | `event.name` | string | `resource` | Required |
 | `event.domain | string | `browser` | Required |
 <!-- endsemconv -->
@@ -18,7 +18,7 @@ Additional attributes are mapped from the (Resource Timing API)[https://www.w3.o
 This list is not exhaustive and is listed as an example. All numeric and string values thar are provided by the Resource Timing API SHOULD be included.
 
 | Attribute  | Type | Example  | Requirement Level |
-|---|---|---|---|---|
+|---|---|---|---|
 | `redirectStart` | numeric | 0 | Optional |
 | `redirectEnd` | numeric | 0 | Optional |
 | `fetchStart` | numeric | 0 | Optional |

--- a/specification/logs/semantic_conventions/events/browser/resource.md
+++ b/specification/logs/semantic_conventions/events/browser/resource.md
@@ -1,0 +1,35 @@
+# Navigation
+
+**Status**: [Experimental](../../../../document-status.md)
+
+**type:** `resource`
+
+**Description**: Represents a resource observed by the browser.
+
+<!-- semconv browser -->
+| Attribute  | Type | Value  | Requirement Level |
+|---|---|---|---|---|
+| `event.name` | string | `resource` | Required |
+| `event.domain | string | `browser` | Required |
+<!-- endsemconv -->
+
+Additional attributes are mapped from the (Resource Timing API)[https://www.w3.org/TR/resource-timing-2/#sec-performanceresourcetiming].
+
+This list is not exhaustive and is listed as an example. All numeric and string values thar are provided by the Resource Timing API SHOULD be included.
+
+| Attribute  | Type | Example  | Requirement Level |
+|---|---|---|---|---|
+| `redirectStart` | numeric | 0 | Optional |
+| `redirectEnd` | numeric | 0 | Optional |
+| `fetchStart` | numeric | 0 | Optional |
+| `domainLookupStart` | numeric | 0 | Optional |
+| `domainLookupEnd` | numeric | 0 | Optional |
+| `connectStart` | numeric | 0 | Optional |
+| `connectEnd` | numeric | 0 | Optional |
+| `secureConnectionStart` | numeric | 0 | Optional |
+| `requestStart` | numeric | 0 | Optional |
+| `responseStart` | numeric | 0 | Optional |
+| `responseEnd` | numeric | 0 | Optional |
+| `transferSize` | numeric | 0 | Optional |
+| `encodedBodySize` | numeric | 0 | Optional |
+| `decodedBodySize` | numeric | 0 | Optional |

--- a/specification/logs/semantic_conventions/events/browser/resource.md
+++ b/specification/logs/semantic_conventions/events/browser/resource.md
@@ -6,6 +6,8 @@
 
 **Description**: Represents a resource observed by the browser.
 
+The following attributes MUST be set with these predefined values:
+
 <!-- semconv browser -->
 | Attribute  | Type | Value  | Requirement Level |
 |---|---|---|---|

--- a/specification/logs/semantic_conventions/events/browser/resource.md
+++ b/specification/logs/semantic_conventions/events/browser/resource.md
@@ -10,26 +10,27 @@
 | Attribute  | Type | Value  | Requirement Level |
 |---|---|---|---|
 | `event.name` | string | `resource` | Required |
-| `event.domain | string | `browser` | Required |
+| `event.domain` | string | `browser` | Required |
 <!-- endsemconv -->
 
-Additional attributes are mapped from the (Resource Timing API)[https://www.w3.org/TR/resource-timing-2/#sec-performanceresourcetiming].
+Additional attributes are mapped from the [Resource Timing API](https://www.w3.org/TR/resource-timing-2/#sec-performanceresourcetiming).
 
 This list is not exhaustive and is listed as an example. All numeric and string values thar are provided by the Resource Timing API SHOULD be included.
 
 | Attribute  | Type | Example  | Requirement Level |
 |---|---|---|---|
-| `redirectStart` | numeric | 0 | Optional |
-| `redirectEnd` | numeric | 0 | Optional |
-| `fetchStart` | numeric | 0 | Optional |
-| `domainLookupStart` | numeric | 0 | Optional |
-| `domainLookupEnd` | numeric | 0 | Optional |
-| `connectStart` | numeric | 0 | Optional |
-| `connectEnd` | numeric | 0 | Optional |
-| `secureConnectionStart` | numeric | 0 | Optional |
-| `requestStart` | numeric | 0 | Optional |
-| `responseStart` | numeric | 0 | Optional |
-| `responseEnd` | numeric | 0 | Optional |
-| `transferSize` | numeric | 0 | Optional |
-| `encodedBodySize` | numeric | 0 | Optional |
-| `decodedBodySize` | numeric | 0 | Optional |
+| `name` | string | `https://example.com/a/b/` | Recommended |
+| `redirectStart` | double | 0 | Recommended |
+| `redirectEnd` | double | 0 | Recommended |
+| `fetchStart` | double | 27.80000112 | Recommended |
+| `domainLookupStart` | double | 33.5 | Recommended |
+| `domainLookupEnd` | double | 60.5999 | Recommended |
+| `connectStart` | double | 60.5999 | Recommended |
+| `connectEnd` | double | 113.7 | Recommended |
+| `secureConnectionStart` | double | 72.8 | Recommended |
+| `requestStart` | double | 114.3 | Recommended |
+| `responseStart` | double | 738.8 | Recommended |
+| `responseEnd` | double | 790.599 | Recommended |
+| `transferSize` | double | 71967 | Recommended |
+| `encodedBodySize` | double | 71667 | Recommended |
+| `decodedBodySize` | double | 364537 | Recommended |

--- a/specification/logs/semantic_conventions/events/events.md
+++ b/specification/logs/semantic_conventions/events/events.md
@@ -1,0 +1,15 @@
+# Event
+
+**Status**: [Experimental](../../../document-status.md)
+
+**type:** `event`
+
+**Description**: All events are described by these attributes.
+
+<!-- semconv browser -->
+| Attribute  | Type | Description  | Examples  | Requirement Level |
+|---|---|---|---|---|
+| `event.name` | string | The event name that uniquely identifies the type of the event within the domain. | `exception`; `interaction` | Required |
+| `event.domain | string | Identifies the group of related events. Each event within a domain MUST have a unique value for the event.name attribute. | `browser`; `mobile` | Recommended |
+| `event.data` | any | Some events/domains may choose to send event attributes as an object or serialized string. | `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.54 Safari/537.36` | Optional |
+<!-- endsemconv -->

--- a/specification/logs/semantic_conventions/events/events.md
+++ b/specification/logs/semantic_conventions/events/events.md
@@ -11,5 +11,8 @@
 |---|---|---|---|---|
 | `event.name` | string | The event name that uniquely identifies the type of the event within the domain. | `exception`; `interaction` | Required |
 | `event.domain` | string | Identifies the group of related events. Each event within a domain MUST have a unique value for the event.name attribute. | `browser`; `mobile` | Recommended |
-| `event.data` | any |  | Recommended |
+| `event.data` | any | It is recommended that event attributes are sent as a nested object value in this attribute. [1] | Recommended |
 <!-- endsemconv -->
+
+
+

--- a/specification/logs/semantic_conventions/events/events.md
+++ b/specification/logs/semantic_conventions/events/events.md
@@ -10,6 +10,6 @@
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | `event.name` | string | The event name that uniquely identifies the type of the event within the domain. | `exception`; `interaction` | Required |
-| `event.domain | string | Identifies the group of related events. Each event within a domain MUST have a unique value for the event.name attribute. | `browser`; `mobile` | Recommended |
-| `event.data` | any | Some events/domains may choose to send event attributes as an object or serialized string. | `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.54 Safari/537.36` | Optional |
+| `event.domain` | string | Identifies the group of related events. Each event within a domain MUST have a unique value for the event.name attribute. | `browser`; `mobile` | Recommended |
+| `event.data` | any |  | Recommended |
 <!-- endsemconv -->


### PR DESCRIPTION
This is a draft of semantic conventions for browser navigation and resource events. It proposed a template for defining semantic conventions for events.

In summary:
* introduce `events` subfolder under /logs/semantic_conventions
* introduce `events.*` attributes, which are required to be present for any event
* conventions for a specific domain are within a subfolder, for example `/logs/semantic_conventions/events/browser` for all browser-related events
* each event type is described in a separate document
* semantic conventions for every event must define the value for the `event.name` and `event.domain` attributes
* any additional attributes specific to a particular event are defined the same way as regular semantic conventions for trace/metrics/logs, with the exception that they do not need to be namespaced
